### PR TITLE
Raise if lookup_for target does not use lookup_by

### DIFF
--- a/lib/lookup_by/association.rb
+++ b/lib/lookup_by/association.rb
@@ -65,7 +65,10 @@ module LookupBy
 
         cast = options[:symbolize] ? ".to_sym" : ""
 
-        lookup_field  = class_name.constantize.lookup.field
+        klass = class_name.constantize
+        raise Error, "class #{class_name} does not use lookup_by" unless klass.respond_to?(:lookup)
+
+        lookup_field  = klass.lookup.field
         lookup_object = "#{class_name}[#{foreign_key}]"
 
         class_eval <<-METHODS, __FILE__, __LINE__.next

--- a/spec/association_spec.rb
+++ b/spec/association_spec.rb
@@ -45,6 +45,10 @@ describe ::ActiveRecord::Base do
       expect { subject.new.city = City.new(name: "Toronto") }.to raise_error ArgumentError, /must be saved/
     end
 
+    it "requires the lookup model to be using lookup_by" do
+      expect { subject.lookup_for :country }.to raise_error LookupBy::Error, /Country does not use lookup_by/
+    end
+
     context "scope: nil" do
       it { should respond_to(:with_city).with(1).arguments }
       it { should respond_to(:with_cities).with(2).arguments }

--- a/spec/dummy/app/models/country.rb
+++ b/spec/dummy/app/models/country.rb
@@ -1,0 +1,2 @@
+class Country < ActiveRecord::Base
+end

--- a/spec/dummy/db/migrate/20121019040009_create_tables.rb
+++ b/spec/dummy/db/migrate/20121019040009_create_tables.rb
@@ -1,6 +1,6 @@
 class CreateTables < ActiveRecord::Migration
   def up
-    create_lookup_tables :cities, :states, :postal_codes, :streets
+    create_lookup_tables :cities, :states, :postal_codes, :streets, :countries
 
     create_lookup_table :user_agents
     create_lookup_table :email_addresses
@@ -21,6 +21,7 @@ class CreateTables < ActiveRecord::Migration
       t.belongs_to :state
       t.belongs_to :postal_code
       t.belongs_to :street
+      t.belongs_to :country
     end
   end
 end

--- a/spec/dummy/db/structure.sql
+++ b/spec/dummy/db/structure.sql
@@ -88,7 +88,8 @@ CREATE TABLE addresses (
     city_id integer,
     state_id integer,
     postal_code_id integer,
-    street_id integer
+    street_id integer,
+    country_id integer
 );
 
 
@@ -138,6 +139,35 @@ CREATE SEQUENCE cities_city_id_seq
 --
 
 ALTER SEQUENCE cities_city_id_seq OWNED BY cities.city_id;
+
+
+--
+-- Name: countries; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE countries (
+    country_id integer NOT NULL,
+    country text NOT NULL
+);
+
+
+--
+-- Name: countries_country_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE countries_country_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: countries_country_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE countries_country_id_seq OWNED BY countries.country_id;
 
 
 --
@@ -388,6 +418,13 @@ ALTER TABLE ONLY cities ALTER COLUMN city_id SET DEFAULT nextval('cities_city_id
 
 
 --
+-- Name: country_id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY countries ALTER COLUMN country_id SET DEFAULT nextval('countries_country_id_seq'::regclass);
+
+
+--
 -- Name: email_address_id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -458,6 +495,14 @@ ALTER TABLE ONLY addresses
 
 ALTER TABLE ONLY cities
     ADD CONSTRAINT cities_pkey PRIMARY KEY (city_id);
+
+
+--
+-- Name: countries_pkey; Type: CONSTRAINT; Schema: public; Owner: -; Tablespace: 
+--
+
+ALTER TABLE ONLY countries
+    ADD CONSTRAINT countries_pkey PRIMARY KEY (country_id);
 
 
 --
@@ -543,6 +588,13 @@ CREATE UNIQUE INDEX cities__u_city ON cities USING btree (city);
 
 
 --
+-- Name: countries__u_country; Type: INDEX; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE UNIQUE INDEX countries__u_country ON countries USING btree (country);
+
+
+--
 -- Name: email_addresses__u_email_address; Type: INDEX; Schema: public; Owner: -; Tablespace: 
 --
 
@@ -614,3 +666,4 @@ CREATE UNIQUE INDEX paths__u_path ON paths USING btree (path);
 SET search_path TO "$user",public;
 
 INSERT INTO schema_migrations (version) VALUES ('20121019040009');
+


### PR DESCRIPTION
The previous behavior was just to let a NoMethodError bubble up in response to calling #lookup on the constantized class name.

Saw someone calling `lookup_for` without a corresponding `lookup_by`, and they just received a less-than-helpful NoMethodError. This will hopefully clarify a bit.
