### PR TITLE
Support Address.where(state: 'TX')

### DIFF
--- a/lib/lookup_by.rb
+++ b/lib/lookup_by.rb
@@ -12,6 +12,9 @@ module LookupBy
   autoload :Lookup,      "lookup_by/lookup"
   autoload :IPAddr,      "ipaddr"
 
+  autoload :QueryMethods,     "lookup_by/query_methods"
+  autoload :PredicateBuilder, "lookup_by/predicate_builder"
+
   module Caching
     autoload :LRU,       "lookup_by/caching/lru"
     autoload :SafeLRU,   "lookup_by/caching/safe_lru"

--- a/lib/lookup_by/association.rb
+++ b/lib/lookup_by/association.rb
@@ -34,8 +34,8 @@ module LookupBy
           attr_reader :lookups
         end
 
-        @lookups ||= []
-        @lookups << field
+        @lookups ||= {}
+        @lookups[field] = options.dup
 
         scope_name = "with_#{field}" unless options[:scope] == false
 
@@ -70,6 +70,11 @@ module LookupBy
 
         lookup_field  = klass.lookup.field
         lookup_object = "#{class_name}[#{foreign_key}]"
+
+        @lookups[field].merge!(
+          class:       klass,
+          foreign_key: foreign_key
+        )
 
         class_eval <<-METHODS, __FILE__, __LINE__.next
           def raw_#{field}

--- a/lib/lookup_by/predicate_builder.rb
+++ b/lib/lookup_by/predicate_builder.rb
@@ -1,0 +1,38 @@
+module LookupBy
+  module PredicateBuilder
+    extend ActiveSupport::Concern
+
+    included do
+      instance_eval do
+        alias :build_from_hash_without_lookup :build_from_hash
+        alias :build_from_hash :build_from_hash_with_lookup
+      end
+    end
+
+    module ClassMethods
+      def build_from_hash_with_lookup(klass, attributes, default_table)
+        unless klass.respond_to? :lookups
+          return build_from_hash_without_lookup(klass, attributes, default_table)
+        end
+
+        attributes = attributes.dup
+        lookups    = klass.lookups
+        attributes.slice(*lookups.keys).each do |attribute, value|
+          next if Hash === value
+
+          attributes.delete(attribute)
+          lookup_class, foreign_key = lookups[attribute].values_at(:class, :foreign_key)
+
+          attributes[foreign_key] =
+            if Array === value
+              value.map { |v| lookup_class[v].id }
+            else
+              lookup_class[value].id
+            end
+        end
+
+        build_from_hash_without_lookup(klass, attributes, default_table)
+      end
+    end
+  end
+end

--- a/lib/lookup_by/query_methods.rb
+++ b/lib/lookup_by/query_methods.rb
@@ -1,0 +1,39 @@
+module LookupBy
+  module QueryMethods
+    extend ActiveSupport::Concern
+
+    included do
+      alias :group_without_lookup :group
+      alias :group :group_with_lookup
+
+      alias :rewhere_without_lookup :rewhere
+      alias :rewhere :rewhere_with_lookup
+    end
+
+    def group_with_lookup(*args)
+      unless klass.respond_to? :lookups
+        group_without_lookup(*args)
+      end
+
+      lookups = klass.lookups.slice(*args)
+      group_without_lookup(args.map { |arg|
+        arg = arg.to_sym
+        lookups.key?(arg) ? lookups[arg][:foreign_key] : arg
+      })
+    end
+
+    def rewhere_with_lookup(conditions)
+      unless klass.respond_to? :lookups
+        rewhere_without_lookup(conditions)
+      end
+
+      lookups = klass.lookups.slice(*conditions.keys)
+      unwhere = conditions.keys.map do |key|
+        key = key.to_sym
+        lookups.key?(key) ? lookups[key][:foreign_key] : key
+      end
+
+      unscope(where: unwhere).where(conditions)
+    end
+  end
+end

--- a/lib/lookup_by/railtie.rb
+++ b/lib/lookup_by/railtie.rb
@@ -14,6 +14,14 @@ module LookupBy
         ActiveRecord::Migration::CommandRecorder.class_eval do
           include Lookup::CommandRecorderMethods
         end
+
+        ActiveRecord::PredicateBuilder.class_eval do
+          include LookupBy::PredicateBuilder
+        end
+
+        ActiveRecord::Relation.instance_eval do
+          include LookupBy::QueryMethods
+        end
       end
     end
   end

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+describe LookupBy, 'querying' do
+  let(:illinois) { State['Illinois'] }
+  let(:new_york) { State['New York'] }
+
+  before do
+    State.lookup.seed('Illinois', 'New York')
+    State.lookup.reload
+  end
+
+  context 'where' do
+    specify 'state = ?' do
+      scope = Address.where(state: 'Illinois')
+      expect(scope.to_sql).to eq Address.where(state_id: illinois.id).to_sql
+    end
+
+    specify 'state IN (?)' do
+      scope = Address.where(state: ['Illinois'])
+      expect(scope.to_sql).to eq Address.where(state_id: [illinois.id]).to_sql
+    end
+
+    specify 'state IN (?, ?)' do
+      scope = Address.where(state: ['Illinois', 'New York'])
+      expect(scope.to_sql).to eq Address.where(state_id: [illinois.id, new_york.id]).to_sql
+    end
+
+    specify 'state <> ?' do
+      scope = Address.where.not(state: 'Illinois')
+      expect(scope.to_sql).to eq Address.where.not(state_id: illinois.id).to_sql
+    end
+  end
+
+  context 'rewhere' do
+    specify 'state = ?' do
+      scope   = Address.where(state: 'Illinois')
+      rescope = scope.rewhere(state: 'New York')
+      expect(rescope.to_sql).to eq Address.where(state_id: new_york.id).to_sql
+    end
+  end
+
+  specify 'group(:state)' do
+    scope = Address.group(:state)
+    expect(scope.to_sql).to eq Address.group(:state_id).to_sql
+  end
+
+  context 'order' do
+    xit 'rewrite to joins(:state).order("states.state"), maybe?'
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,6 +40,9 @@ RSpec.configure do |config|
   #     --seed 1234
   config.order = "random"
 
+  config.filter_run :focus => true
+  config.run_all_when_everything_filtered = true
+
   config.before(:suite) do
     DatabaseCleaner.strategy = :transaction
   end


### PR DESCRIPTION
Proof of concept. As best I can tell, the only means of implementing this is to re-open the guts of Rails, which is probably a maintenance nightmare.
- Works on AR 4.1.4, maybe 4.x, likely not 3.2.x. The tests, at least, would definitely fail on 3.2, as it doesn't have `where.not()`. See #17.
- Functionality is limited to `where`, `rewhere`, and `group` for right now.
- No tests on error cases; if `State['TX']` didn't exist, there'd just be a `NoMethodError id on nil` thrown. #15 might help a bit.
- Implementing something like `order` is less obvious: it'll force a join if we really want to order on value.
- Dunno what `includes(:state)` should really do; if the class has a local cache, we probably _don't_ want to eager load it, but it could very well be `includes(state: [:country, :continent])` or some such, in which case we might have to. Tough to reason about.
