### PR TITLE
lookup_for scopes: n-arity; name the scope what you want; inverse scoping.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ lookup_by :column_name
 
 lookup_for :status
 # Defines #status and #status= instance methods that transparently reference the lookup table.
-# Defines .with_status(name) and .with_statuses(*names) scopes on the model.
+# Defines .with_status(*names) and .without_status(*names) scopes on the model.
 ```
 
 ### Define the lookup model


### PR DESCRIPTION
This modifies the `lookup_for :foo, scope: ...` behavior to:
1. Only a single scope is defined, which is n-arity. This is backwards incompatible if you previously used the plural form `with_foos`. I could've left it defined, but meh. Pre-1.0!
2. You can now pass `scope: :wudevs` to have your scope named `wudevs`.
3. An additional option `:inverse_scope` is introduced, essentially wrapping `where.not(...)` but with Rails 3 compatibility.

Mostly, I want to delete a module `ScopeByLookup` that I copy&paste into every app I work on that uses lookup_by.
