### PR TITLE
Use SafeLRU on Rails 4

### DIFF
--- a/lib/lookup_by/cache.rb
+++ b/lib/lookup_by/cache.rb
@@ -33,7 +33,7 @@ module LookupBy
 
         @type    = :lru
         @limit   = options[:cache]
-        @cache   = Rails.configuration.allow_concurrency ? Caching::SafeLRU.new(@limit) : Caching::LRU.new(@limit)
+        @cache   = concurrency_enabled? ? Caching::SafeLRU.new(@limit) : Caching::LRU.new(@limit)
         @read    = true
         @write ||= false
         @testing = true if Rails.env.test? && @write
@@ -188,6 +188,11 @@ module LookupBy
 
     def increment(type, stat)
       @stats[type][stat] += 1
+    end
+
+    def concurrency_enabled?
+      return true if Rails.configuration.allow_concurrency
+      Rails::VERSION::MAJOR > 3 && Rails.configuration.cache_classes && Rails.configuration.eager_load
     end
   end
 end


### PR DESCRIPTION
Currently, whether to use thread safe caching or not is determined by calling `Rails.configuration.allow_concurrency`.

This is set inside `config.threadsafe!`, which is deprecated in Rails 4.

Thread safety is turned on by default in Rails 4, as long as `config.cache_classes` and `config.eager_load` are both true.

This pull requests allow Rails 4 apps to use SafeLRU without setting deprecated config options.

References:
http://tenderlovemaking.com/2012/06/18/removing-config-threadsafe.html
https://github.com/rails/rails/commit/5d416b907864d99af55ebaa400fff217e17570cd
