### PR TITLE
Fix logic to select SafeLRU when using Rails 4

### DIFF
--- a/lib/lookup_by/cache.rb
+++ b/lib/lookup_by/cache.rb
@@ -33,7 +33,7 @@ module LookupBy
 
         @type    = :lru
         @limit   = options[:cache]
-        @cache   = Rails.configuration.allow_concurrency ? Caching::SafeLRU.new(@limit) : Caching::LRU.new(@limit)
+        @cache   = concurrent? ? Caching::SafeLRU.new(@limit) : Caching::LRU.new(@limit)
         @read    = true
         @write ||= false
         @testing = true if Rails.env.test? && @write
@@ -130,6 +130,15 @@ module LookupBy
     end
 
   private
+
+    def concurrent?
+      case Rails::VERSION::MAJOR
+      when 4 then Rails.configuration.cache_classes && Rails.configuration.eager_load
+      when 3 then Rails.configuration.allow_concurrency
+      else
+        true
+      end
+    end
 
     def primary_key?(value)
       case @primary_key_type


### PR DESCRIPTION
Modified commit below from @mlarraz.

> Currently, whether to use thread safe caching or not is determined by
> calling Rails.configuration.allow_concurrency.
> 
> This is set inside config.threadsafe!, which is deprecated in Rails 4.
> 
> Thread safety is turned on by default in Rails 4, as long as
> config.cache_classes and config.eager_load are both true.
> 
> This pull requests allow Rails 4 apps to use SafeLRU without setting
> deprecated config options.
> 
> References:
> http://tenderlovemaking.com/2012/06/18/removing-config-threadsafe.html
> rails/rails@5d416b9
