### PR TITLE
Add CHANGELOG with changes from last two versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,38 @@
+### [v0.11.1](https://github.com/companygardener/lookup_by/compare/v0.11.0...v0.11.1)
+
+#### Fix .all on lookup models
+
+Version 0.11.0 breaks Model.where(field: 'value').first_or_create! when
+Model is configured with `lookup_by :field, cache: true`.
+
+### [v0.11.0](https://github.com/companygardener/lookup_by/compare/v0.10.9...v0.11.0)
+
+#### Rails 5.0.0 support
+
+Update .count signature to support Rails 5.
+
+- Require ruby 2.2.2+
+- PostgreSQL 9.2+
+- Drop support for JRuby
+
+#### Default to a threadsafe cache
+
+### [v0.10.9](https://github.com/companygardener/lookup_by/compare/v0.10.8...v0.10.9)
+
+### [v0.10.8](https://github.com/companygardener/lookup_by/compare/v0.10.7...v0.10.8)
+
+### [v0.10.7](https://github.com/companygardener/lookup_by/compare/v0.10.6...v0.10.7)
+
+### [v0.10.6](https://github.com/companygardener/lookup_by/compare/v0.10.5...v0.10.6)
+
+### [v0.10.5](https://github.com/companygardener/lookup_by/compare/v0.10.4...v0.10.5)
+
+### [v0.10.4](https://github.com/companygardener/lookup_by/compare/v0.10.3...v0.10.4)
+
+### [v0.10.3](https://github.com/companygardener/lookup_by/compare/v0.10.2...v0.10.3)
+
+### [v0.10.2](https://github.com/companygardener/lookup_by/compare/v0.10.1...v0.10.2)
+
+### [v0.10.1](https://github.com/companygardener/lookup_by/compare/v0.10.0...v0.10.1)
+
+### [v0.10.0](https://github.com/companygardener/lookup_by/compare/v0.9.1...v0.10.0)


### PR DESCRIPTION
And links to compare views for all versions going back to v0.10.0

(e.g. `0.10.9 -> 0.11.1` breaks my tests, I wanted to know why)