### PR TITLE
Add example of using :scope and :inverse_scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ class ExampleObject < ActiveRecord::Base
   # Defines #status and #status= instance methods that transparently reference the lookup table.
   # Defines .with_status(*names) and .without_status(*names) scopes on the model.
 end
+
+class Address < ActiveRecord::Base
+  # scopes can be renamed
+  lookup_for :city, scope: :inside_city, inverse_scope: :outside_city
+end
 ```
 
 ### Define the lookup model


### PR DESCRIPTION
I found those (and the fact that `with_` and `without_` scopes are added by default) in the specs :)