### PR TITLE
[Rails 5] Rewrite using `#alias_method`

### DIFF
--- a/lib/lookup_by/hooks/formtastic.rb
+++ b/lib/lookup_by/hooks/formtastic.rb
@@ -6,7 +6,8 @@ module LookupBy
       extend ActiveSupport::Concern
 
       included do
-        alias_method_chain :input, :lookup
+        alias_method :input_without_lookup, :input
+        alias_method :input, :input_with_lookup
       end
 
       def input_with_lookup(method, options = {})

--- a/lib/lookup_by/hooks/simple_form.rb
+++ b/lib/lookup_by/hooks/simple_form.rb
@@ -6,7 +6,8 @@ module LookupBy
       extend ActiveSupport::Concern
 
       included do
-        alias_method_chain :input, :lookup
+        alias_method :input_without_lookup, :input
+        alias_method :input, :input_with_lookup
       end
 
       def input_with_lookup(method, options = {}, &block)


### PR DESCRIPTION
Rails 5 deprecates `#alias_method_chain`. See: https://github.com/rails/rails/pull/19434