### PR TITLE
Updating the SimpleForm hook to use prepend instead of send 

### DIFF
--- a/lib/lookup_by/hooks/simple_form.rb
+++ b/lib/lookup_by/hooks/simple_form.rb
@@ -25,4 +25,4 @@ module LookupBy
   end
 end
 
-::SimpleForm::FormBuilder.send :include, LookupBy::Hooks::SimpleForm
+::SimpleForm::FormBuilder.send :prepend, LookupBy::Hooks::SimpleForm


### PR DESCRIPTION
Updating the hook to use prepend instead of send to resolve the issue of `alias_method` not resolving properly in Rails 6