### PR TITLE
Pass create_table options with a double-splat

### DIFF
--- a/lib/lookup_by/lookup.rb
+++ b/lib/lookup_by/lookup.rb
@@ -180,7 +180,7 @@ module LookupBy
 
         table_options[:id] = false if options[:small]
 
-        create_table name, table_options do |t|
+        create_table name, **table_options do |t|
           t.column table_options[:primary_key], 'smallserial primary key' if options[:small]
 
           t.column lookup_column, lookup_type, null: false


### PR DESCRIPTION
`create_lookup_table` fails on Ruby > 3 as it differentiates keyword arguments and hashes. Change resolves arity error.