### PR TITLE
feat: add option to fail loudly when db is unavailable

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,25 @@ Can be useful to handle `params` that are not required.
 lookup_by :column_name, allow_blank: true
 ```
 
+### Fail loudly on initialization errors
+
+By default, LookupBy silently skips initialization if the database is
+unreachable at boot (logging the error and moving on). This avoids breaking the
+situations where the database is expectedly unavailable (originally, this was
+added to handle precompiling assets on build nodes), but it means that a live
+instance of the app can end up in a broken state if the database is unreachable
+when it originally boots.
+
+Set `fail_loudly` to raise instead, so broken apps fail fast:
+
+```ruby
+# config/initializers/lookup_by.rb
+LookupBy.fail_loudly = true
+```
+
+This is recommended, but opt-in for now. The setting may become the default behavior
+in a future major release.
+
 ### Threadsafety
 
 Disable threadsafety using the `:safe` option.

--- a/lib/lookup_by.rb
+++ b/lib/lookup_by.rb
@@ -12,6 +12,8 @@ module LookupBy
   mattr_accessor :mutex
   self.mutex = Mutex.new
 
+  self.fail_loudly = false
+
   UUID_REGEX    = /\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\Z/
   UUID_REGEX_V4 = /\A\h{8}-\h{4}-4\h{3}-[89aAbB]\h{3}-\h{12}\Z/
 
@@ -26,6 +28,8 @@ module LookupBy
   end
 
   class << self
+    attr_accessor :fail_loudly
+
     def register(klass)
       mutex.synchronize do
         self.classes << klass unless classes.include?(klass)

--- a/lib/lookup_by/association.rb
+++ b/lib/lookup_by/association.rb
@@ -27,6 +27,8 @@ module LookupBy
         begin
           return unless table_exists?
         rescue => error
+          raise error if options.fetch(:fail_loudly, LookupBy.fail_loudly)
+
           Rails.logger.error "lookup_by caught #{error.class.name} when connecting - skipping initialization (#{error.inspect})"
           return
         end

--- a/lib/lookup_by/lookup.rb
+++ b/lib/lookup_by/lookup.rb
@@ -24,6 +24,8 @@ module LookupBy
         begin
           return unless table_exists?
         rescue => error
+          raise error if options.fetch(:fail_loudly, LookupBy.fail_loudly)
+
           Rails.logger.error "lookup_by caught #{error.class.name} when connecting - skipping initialization (#{error.inspect})"
           return
         end


### PR DESCRIPTION
If the database is unavailable when LookupBy attempts to initialize its association or lookup methods, it silently aborts and leaves behind incomplete classes and a busted app. Adding an option to fail loudly will make the app fail to boot in these scenarios and avoid coming up broken.